### PR TITLE
Add client directives to hook-using components

### DIFF
--- a/app/assessment/nutrition-assessment.tsx
+++ b/app/assessment/nutrition-assessment.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useState } from 'react';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { Alert, AlertDescription } from '@/components/ui/alert';

--- a/components/NutritionAssessmentApp.tsx
+++ b/components/NutritionAssessmentApp.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useEffect, useState } from 'react';
 import usePatientStore from '../stores/usePatientStore';
 import {

--- a/components/NutritionDiarySystem.tsx
+++ b/components/NutritionDiarySystem.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useState, useEffect } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from './ui/card';
 import { Alert, AlertDescription, AlertTitle } from './ui/alert';

--- a/components/NutritionMonitoringDashboard.tsx
+++ b/components/NutritionMonitoringDashboard.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from './ui/card';
 import {

--- a/components/SupplementInteractionChecker.tsx
+++ b/components/SupplementInteractionChecker.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useEffect } from 'react';
 import useSupplementStore from '../stores/useSupplementStore';
 import { useState, useEffect } from 'react';


### PR DESCRIPTION
## Summary
- mark various components as client components for Next.js

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684487eabcc88329be150fb066148104